### PR TITLE
ProgressBar

### DIFF
--- a/src/components/bar/progressBar.tsx
+++ b/src/components/bar/progressBar.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface ProgressBarProps {
+  progress: number;
+}
+
+const ProgressBar = ({ progress }: ProgressBarProps) => {
+  return (
+    <div className="mb-1">
+      <div className="flex justify-between items-center mb-1">
+        <span className="text-base font-semibold">{progress}%</span>
+      </div>
+      <div className="w-full bg-grey_1 rounded-full h-3">
+        <div
+          className="bg-grey_6 h-3 rounded-full"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ProgressBar;

--- a/src/components/bar/progressBar.tsx
+++ b/src/components/bar/progressBar.tsx
@@ -6,15 +6,27 @@ interface ProgressBarProps {
 
 const ProgressBar = ({ progress }: ProgressBarProps) => {
   return (
-    <div className="mb-1">
-      <div className="flex justify-between items-center mb-1">
-        <span className="text-base font-semibold">{progress}%</span>
-      </div>
-      <div className="w-full bg-grey_1 rounded-full h-3">
+    // <div className="mb-1">
+    //   <div className="flex justify-between items-center mb-1">
+    //     <span className="text-base font-semibold">{progress}%</span>
+    //   </div>
+    //   <div className="w-full bg-grey_1 rounded-full h-3">
+    //     <div
+    //       className="bg-grey_6 h-3 rounded-full"
+    //       style={{ width: `${progress}%` }}
+    //     />
+    //   </div>
+    // </div>
+    <div className="mb-1 mt-4 relative">
+      {/* 디자인 제안! */}
+      <div className="w-full bg-grey_1 rounded-full h-4">
         <div
-          className="bg-grey_6 h-3 rounded-full"
+          className="bg-grey_6 h-4 rounded-full"
           style={{ width: `${progress}%` }}
-        />
+        ></div>
+        <div className="absolute inset-0 flex justify-center items-center">
+          <span className="text-base font-semibold">{progress}%</span>
+        </div>
       </div>
     </div>
   );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,6 +3,9 @@ export { default as Layout } from './layout/layout';
 export { default as Header } from './layout/header';
 export { default as Sidebar } from './layout/sideBar';
 
+// bar
+export { default as ProgressBar } from './bar/progressBar';
+
 // button
 export { default as Button } from './button/button';
 export { default as ZoomButtons } from './button/zoomButtons';

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -39,7 +39,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className="relative flex h-screen bg-basic_1">
       <Header />
-      <Sidebar data={cardData} />
+      <Sidebar data={cardData} progress={30} />
       <div className="flex flex-col flex-1 ml-[300px] mt-[56px]">
         <div className="flex-1 overflow-y-auto bg-basic_1 p-4 bg-grey_0">
           <main className={`relative ${isHandMode ? 'hand-mode' : ''}`}>

--- a/src/components/layout/sideBar.tsx
+++ b/src/components/layout/sideBar.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Button, Card } from '@/components';
+import { Button, Card, ProgressBar } from '@/components';
 
 interface SidebarProps {
   data: any[];
+  progress: number;
 }
 
-const Sidebar = ({ data }: SidebarProps) => {
+const Sidebar = ({ data, progress }: SidebarProps) => {
   return (
     <div className="fixed top-0 left-0 w-[300px] h-full flex flex-col bg-white p-4 border-r-2 border-grey_2 pt-20">
       <div className="flex-grow overflow-y-auto scrollbar-hide">
@@ -20,6 +21,7 @@ const Sidebar = ({ data }: SidebarProps) => {
         ))}
       </div>
       <div className="flex-shrink-0">
+        <ProgressBar progress={progress} />
         <Button title={'추가하기'} />
       </div>
     </div>


### PR DESCRIPTION
# 구현 사항 [완료] 🥦

### progress bar component ☂️

> 기존 디자인 
![image](https://github.com/user-attachments/assets/08e5e565-9c55-40d2-b436-5420038336e5)

> 제안 디자인
![image](https://github.com/user-attachments/assets/75d4cedf-2c85-435b-9932-a1873e3491cf)


-> text가 progress bar 위에 위치할 경우 카드 영역이 작아져서 bar 위에 올리는게 좋을것 같은데 어떻게 생각하시나요?!
퍼센트가 50을 넘어갈 경우 텍스트와 겹치게 되는데, 색상을 어떻게 해야할 지 모르겠네요ㅡ,.ㅡ

![image](https://github.com/user-attachments/assets/8d1cc556-15be-4a6b-b6f6-664c4c1316bb)

