### PR TITLE
[Feat] Containerization tool

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 API_URL=http://host.docker.internal:2387
+BACKEND_API_URL=http://localhost:2387
 DOCKER_URL=http://host.docker.internal:2375
 HUB_URL=https://hub.docker.com/v2

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-API_URL=http://localhost:2387
-DOCKER_URL=http://localhost:2375
+API_URL=http://host.docker.internal:2387
+DOCKER_URL=http://host.docker.internal:2375
 HUB_URL=https://hub.docker.com/v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:21-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+
+RUN npm install
+
+COPY . .
+
+RUN npm run build
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:21-alpine
+FROM node:21-slim
 
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,9 @@ services:
       - '3000:3000'
     environment:
       API_URL: http://host.docker.internal:2387
+      BACKEND_API_URL: http://localhost:2387
+      DOCKER_URL: http://host.docker.internal:2375
+      HUB_URL: https://hub.docker.com/v2
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     command: npm run dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: goraebab-frontend
+    ports:
+      - '3000:3000'
+    environment:
+      API_URL: http://host.docker.internal:2387
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: npm run dev

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,5 @@
 /** @type {import('next').NextConfig} */
-const API_URL = 'http://localhost:2387';
+const API_URL = process.env.API_URL;
 
 const nextConfig = {
   reactStrictMode: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "my-app",
-  "version": "0.1.0",
+  "name": "goraebab",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/axiosInstance.ts
+++ b/src/app/api/axiosInstance.ts
@@ -4,22 +4,25 @@ import os from 'os';
 export const createDockerClient = (hostIp?: string | null) => {
   const effectiveHost =
     hostIp === null || hostIp === undefined
-      ? sessionStorage.getItem('selectedHostIp') || 'localhost'
+      ? sessionStorage.getItem('selectedHostIp') || 'host.docker.internal'
       : hostIp;
 
   // IP 주소와 포트를 정규식으로 파싱
   const ipPortRegex = /^((?:\d{1,3}\.){3}\d{1,3})(?::(\d+))?$/;
   const match = effectiveHost.match(ipPortRegex);
 
-  let host = effectiveHost;
+  const isLocalhost =
+    effectiveHost === 'localhost' ||
+    effectiveHost === '127.0.0.1' ||
+    effectiveHost === 'host.docker.internal';
+
+  let host = isLocalhost ? 'host.docker.internal' : effectiveHost;
   let port = '2375';
 
   if (match) {
     host = match[1];
     port = match[2] || '2375';
   }
-
-  const isLocalhost = host === 'localhost' || host === '127.0.0.1';
 
   // Windows인 경우 다른 소켓 경로 사용
   const isWindows = os.platform() === 'win32';
@@ -29,12 +32,12 @@ export const createDockerClient = (hostIp?: string | null) => {
 
   const options = isLocalhost
     ? {
-      baseURL: 'http://localhost',
-      socketPath: dockerSocketPath,
-    }
+        baseURL: `http://${host}`,
+        socketPath: dockerSocketPath,
+      }
     : {
-      baseURL: `http://${host}:${port}`,
-    };
+        baseURL: `http://${host}:${port}`,
+      };
 
   return axios.create(options);
 };

--- a/src/app/api/blueprint/create/route.ts
+++ b/src/app/api/blueprint/create/route.ts
@@ -1,22 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
 import axios from 'axios';
+import { BASE_URL } from '../../urlPath';
 
 export async function POST(req: NextRequest) {
   const bodyData = await req.json();
 
   try {
-    const response = await axios.post(`api/v1/blueprints`, {});
+    const response = await axios.post(`${BASE_URL}/blueprints`, {});
     return NextResponse.json(response.data, { status: 200 });
   } catch (error) {
     if (error instanceof Error && (error as any).response) {
       return NextResponse.json(
         { error: (error as any).response.data.message },
-        { status: 500 },
+        { status: 500 }
       );
     }
     return NextResponse.json(
       { error: 'Failed to create container' },
-      { status: 500 },
+      { status: 500 }
     );
   }
 }

--- a/src/app/api/blueprint/list/route.ts
+++ b/src/app/api/blueprint/list/route.ts
@@ -1,22 +1,22 @@
 import { NextResponse } from 'next/server';
 import axios from 'axios';
-import { API_URL } from '@/app/api/urlPath';
+import { BASE_URL } from '@/app/api/urlPath';
 
 export async function GET() {
   try {
-    const response = await axios.get(`${API_URL}/blueprints`);
+    const response = await axios.get(`${BASE_URL}/blueprints`);
     return NextResponse.json(response.data, { status: 200 });
   } catch (error) {
     console.log(error);
     if (error instanceof Error && (error as any).response) {
       return NextResponse.json(
         { error: (error as any).response.data.message },
-        { status: 500 },
+        { status: 500 }
       );
     }
     return NextResponse.json(
       { error: 'Failed to create container' },
-      { status: 500 },
+      { status: 500 }
     );
   }
 }

--- a/src/app/api/urlPath.ts
+++ b/src/app/api/urlPath.ts
@@ -1,5 +1,5 @@
-export const API_URL = 'http://localhost:2387';
-export const DOCKER_URL = 'http://localhost:2375';
+export const API_URL = 'http://host.docker.internal:2387';
+export const DOCKER_URL = 'http://host.docker.internal:2375';
 export const HUB_URL = 'https://hub.docker.com/v2';
 export const BASE_URL = '/api/v1';
 

--- a/src/app/api/urlPath.ts
+++ b/src/app/api/urlPath.ts
@@ -1,7 +1,9 @@
 export const API_URL = 'http://host.docker.internal:2387';
+export const BACKEND_API_URL = 'http://localhost:2387';
 export const DOCKER_URL = 'http://host.docker.internal:2375';
 export const HUB_URL = 'https://hub.docker.com/v2';
-export const BASE_URL = '/api/v1';
+// export const BASE_URL = '/api/v1';
+export const BASE_URL = 'http://localhost:2387';
 
 // blueprint
 export const STORAGE = '/storage';


### PR DESCRIPTION
📢 Issue
> front service를 컨테이너로 띄웠을 때 localhost 에러 발생

도커 컨테이너가 접근 할 수 있도록 `localhost`를  `host.docker.internal`으로 수정함.

`docker-compose up --build` 명령어 사용해서 테스트할 수 있으며 컨테이너를 실행시켰을 때 docker api를 포함한 모든 api 요청이 정상적으로 이루어짐.
 